### PR TITLE
Fix deprecated CSR names

### DIFF
--- a/benchmarks/pma/pma.c
+++ b/benchmarks/pma/pma.c
@@ -98,7 +98,7 @@ static void init_pt()
 #else
   uintptr_t vm_choice = SATP_MODE_SV32;
 #endif
-  write_csr(sptbr, ((uintptr_t)l1pt >> RISCV_PGSHIFT) |
+  write_csr(satp, ((uintptr_t)l1pt >> RISCV_PGSHIFT) |
                    (vm_choice * (SATP_MODE & ~(SATP_MODE<<1))));
   write_csr(0x7ca, -1);
   write_csr(0x7c0, (PMP_NAPOT | PMP_R | PMP_W | PMP_X) << 16);

--- a/benchmarks/pmp-modified/pmp.c
+++ b/benchmarks/pmp-modified/pmp.c
@@ -98,7 +98,7 @@ static void init_pt()
 #else
   uintptr_t vm_choice = SATP_MODE_SV32;
 #endif
-  write_csr(sptbr, ((uintptr_t)l1pt >> RISCV_PGSHIFT) |
+  write_csr(satp, ((uintptr_t)l1pt >> RISCV_PGSHIFT) |
                    (vm_choice * (SATP_MODE & ~(SATP_MODE<<1))));
   write_csr(pmpaddr2, -1);
   write_csr(pmpcfg0, (PMP_NAPOT | PMP_R | PMP_W | PMP_X) << 16);

--- a/env/xs-southlake/riscv_test.h
+++ b/env/xs-southlake/riscv_test.h
@@ -110,7 +110,7 @@
 #define INIT_SATP                                                      \
   la t0, 1f;                                                            \
   csrw mtvec, t0;                                                       \
-  csrwi sptbr, 0;                                                       \
+  csrwi satp, 0;                                                        \
   .align 2;                                                             \
 1:
 

--- a/env/xs/riscv_test.h
+++ b/env/xs/riscv_test.h
@@ -110,7 +110,7 @@
 #define INIT_SATP                                                      \
   la t0, 1f;                                                            \
   csrw mtvec, t0;                                                       \
-  csrwi sptbr, 0;                                                       \
+  csrwi satp, 0;                                                        \
   .align 2;                                                             \
 1:
 

--- a/isa/rv64mi/xtvec.S
+++ b/isa/rv64mi/xtvec.S
@@ -92,7 +92,7 @@ synchronous_exception:
   csrr t0, mepc
 
   # Make sure mtval contains either 0 or the instruction word.
-  csrr t2, mbadaddr
+  csrr t2, mtval
   beqz t2, 1f
   lhu t1, 0(t0)
   xor t2, t2, t1

--- a/isa/rv64si/satp_ppn.S
+++ b/isa/rv64si/satp_ppn.S
@@ -17,7 +17,7 @@ RVTEST_CODE_BEGIN
   #define sscratch mscratch
   #define sstatus mstatus
   #define scause mcause
-  #define sbadaddr mbadaddr
+  #define stval mtval
   #define sepc mepc
   #define sret mret
   #define stvec_handler mtvec_handler


### PR DESCRIPTION
This commits replaced the deprecated CSR names in source files with corresponding CSR names in current standard. The new code is checked to make sure this change does not break the functions modified. But further checkes are still required to make sure the tests comply with latest standards.